### PR TITLE
Add a switch to use podman instead of docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ services: docker
 env:
   global:
     - ROLE_NAME: mariadb
+    - DRIVER_NAME: docker
   matrix:
     - MOLECULE_DISTRO: debian-10
     - MOLECULE_DISTRO: debian-sid

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -2,7 +2,7 @@
 dependency:
   name: galaxy
 driver:
-  name: docker
+  name: ${DRIVER_NAME:-podman}
 platforms:
   - name: instance
     image: "fauust/docker-ansible:${MOLECULE_DISTRO:-debian-10}"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ ansible==2.9.*
 docker
 flake8
 mitogen
-molecule
+molecule==3.0.*
 testinfra
 yamllint


### PR DESCRIPTION
This permits to use podman locally to run molecule tests, next step is to use it in CI too.
But first I should pass to molecule v3.1.