### PR TITLE
Update molecule

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 ansible==2.9.*
 docker
 mitogen
-molecule==3.0.*
-testinfra
+molecule==3.1.*
+molecule-docker
+pytest-testinfra


### PR DESCRIPTION
This update molecule to latest 3.1 branch:
- installation of molecule-docker is now needed;
- testinfra was renamed.