### PR TITLE
Using podman for github actions

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -12,6 +12,7 @@ jobs:
     name: Molecule
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         include:
           - distro: ubuntu-18.04
@@ -34,16 +35,19 @@ jobs:
             playbook: converge.yml
 
     steps:
+      # see https://github.com/actions/virtual-environments/issues/3536#issuecomment-858433636)
+      # - name: Set rights for podman
+      #   run: sudo chmod o+rwx -R /sys/fs/cgroup/systemd
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
       - name: Install requirements
-        run: pip3 install -r requirements.txt
-
+        run: |
+          sudo python3 -m pip install --upgrade pip
+          sudo python3 -m pip install -r requirements.txt
       - name: Run molecule
-        run: molecule test
+        # using sudo see https://github.com/actions/virtual-environments/issues/3536
+        run: sudo molecule test
         env:
           PY_COLORS: "1"
           ANSIBLE_FORCE_COLOR: "1"
-          DRIVER_NAME: "docker"
           MOLECULE_DISTRO: ${{ matrix.distro }}
           MOLECULE_PLAYBOOK: ${{ matrix.playbook }}

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,21 +1,17 @@
 ---
-dependency:
-  name: galaxy
 driver:
-  name: ${DRIVER_NAME:-podman}
+  name: podman
 platforms:
   - name: instance
     image: "fauust/docker-ansible:${MOLECULE_DISTRO:-debian-10}"
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: true
-    command: /lib/systemd/systemd
+    command: "/lib/systemd/systemd"
 provisioner:
   name: ansible
   env:
     ANSIBLE_GATHERING: explicit
     ANSIBLE_FORCE_COLOR: true
-    ANSIBLE_PYTHON_INTERPRETER: /usr/bin/python3
   playbooks:
     converge: ${MOLECULE_PLAYBOOK:-converge.yml}
 verifier:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,4 @@
-ansible==2.9.*
-#ansible==2.10.*
-mitogen
-#https://github.com/mitogen-hq/mitogen/archive/v0.3.0-rc.0.tar.gz
-molecule==3.2.*
-molecule-docker
+ansible==2.10.*
+molecule==3.3.*
+molecule-podman
 pytest-testinfra


### PR DESCRIPTION
Docker with systemd does not work.
Also, it's using sudo for the moment because the rootless container does
not work with GH actions (see: https://github.com/actions/virtual-environments/issues/3536).