### PR TITLE
Enhance and clean Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,30 +1,31 @@
 VENV_DIR := .venv
-SHELL := /usr/bin/env bash
+SHELL := bash
 .DEFAULT_GOAL := help
+.ONESHELL:
 
 help:
-	@grep -E '^[a-zA-Z1-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) \
-		| awk 'BEGIN { FS = ":.*?## " }; { printf "\033[36m%-30s\033[0m %s\n", $$1, $$2 }'
+	@grep '^#?.*' $(MAKEFILE_LIST) \
+	| awk -F ':' '{ $$1 = substr($$1, 4); printf "\033[36m%-30s\033[0m %s\n", $$1, $$2 }'
 
-install: ## Install all necessary tools
-	$(MAKE) \
-		venv \
-		install-pip-packages
-	@echo -e "\n--> You should now activate the python3 venv with:"
-	@echo -e "source $(VENV_DIR)/bin/activate"
+$(VENV_DIR):
+	$(shell command -v python3) -m venv $(VENV_DIR)
 
-venv: ## Create python3 venv if it does not exists
-	[[ -d $(VENV_DIR) ]] || $(shell command -v python3) -m venv $(VENV_DIR)
+#? install: Install all necessary tools
+install: install-pip-packages
+	@$(info --> You should now activate the python3 venv with:)
+	@$(info source $(VENV_DIR)/bin/activate)
 
-install-pip-packages: ## Install python3 requirements
-	$(info --> Install requirements via `pip3`)
-	@( \
-			source $(VENV_DIR)/bin/activate; \
-			pip3 install -r requirements.txt; \
-	)
+#? install-pip-packages: Install python3 requirements
+install-pip-packages: $(VENV_DIR)
+	@$(info --> Install requirements via `pip3`)
+	@source $(VENV_DIR)/bin/activate
+	@pip3 install -r requirements.txt
 
-upgrade-pip-packages: ## Upgrade python3 requirements
-	$(shell command -v pip3) -U -r requirements.txt
+#? upgrade-pip-packages: Upgrade python3 requirements
+upgrade-pip-packages: $(VENV_DIR)
+	@source $(VENV_DIR)/bin/activate
+	@pip3 install --upgrade -r requirements.txt
 
-clean: ## Clean venv
+#? clean: Clean venv
+clean:
 	[[ ! -d $(VENV_DIR) ]] || rm -rf $(VENV_DIR)


### PR DESCRIPTION
- Use .ONESHELL to use the same shell for a single goal. This allows to stay in a venv without dirty (cmd; \ cmd; \) hacks.
- Replace /usr/bin/env bash with bash, as it doesn't work with .ONESHELL.
- Use make targets dependencies to check it was reached.
- Simplify help generator and make help comment obvious.