### PR TITLE
Fix #15 and replace deprecated variables

### DIFF
--- a/molecule/default/converge-mdbf.yml
+++ b/molecule/default/converge-mdbf.yml
@@ -3,7 +3,6 @@
   hosts: all
   gather_facts: true
   vars:
-    ansible_python_interpreter: /usr/bin/python3
     mariadb_use_official_repo: true
     mariadb_use_official_repo_url: https://archive.mariadb.org/mirror/repo
     mariadb_use_official_repo_version: 10.5

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -2,8 +2,6 @@
 - name: Converge
   hosts: all
   gather_facts: true
-  vars:
-    ansible_python_interpreter: /usr/bin/python3
   vars_files: vars/testvars.yml
 
   roles:

--- a/tasks/replication_replica.yml
+++ b/tasks/replication_replica.yml
@@ -1,7 +1,7 @@
 ---
 - name: Check replica replication status
   mysql_replication:
-    mode: getslave
+    mode: getreplica
     login_unix_socket: "{{ mariadb_unix_socket }}"
   register: replica
   no_log: true
@@ -15,7 +15,7 @@
     master_user='{{ item.name }}', master_password='{{ item.password }}', master_use_gtid=slave_pos"
   loop: "{{ mariadb_replication_user }}"
   when:
-    - not replica.Is_Slave
+    - not replica.Is_Replica
   no_log: true
 
 # # Following (not tested) should work on ansible 2.10
@@ -34,21 +34,21 @@
 
 - name: Reset replica replication
   mysql_replication:
-    mode: resetslave
+    mode: resetreplica
     login_unix_socket: "{{ mariadb_unix_socket }}"
   when:
-    - not replica.Is_Slave
+    - not replica.Is_Replica
 
 - name: Check replica replication status (second time)
   mysql_replication:
-    mode: getslave
+    mode: getreplica
     login_unix_socket: "{{ mariadb_unix_socket }}"
   register: replica2
   no_log: true
 
 - name: Start replica replication
   mysql_replication:
-    mode: startslave
+    mode: startreplica
     login_unix_socket: "{{ mariadb_unix_socket }}"
   when:
     - replica2.Slave_IO_Running == "No"

--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -30,7 +30,7 @@
 
 - name: Determine required MariaDB Python libraries
   set_fact:
-    deb_mariadb_python_package: "{% if 'python3' in ansible_python_interpreter|default('') %}python3-pymysql{% else %}python-pymysql{% endif %}"
+    deb_mariadb_python_package: "{% if 'python3' in discovered_interpreter_python|default('') %}python3-pymysql{% else %}python-pymysql{% endif %}"
 
 - name: Install python mariadb driver
   apt:


### PR DESCRIPTION
As discussed, moving from `ansible_python_interpreter` to `discovered_interpreter_python`. 

And while I'm at it, /s/slave/replica/g to get rid of the deprecation warnings.