### PR TITLE
Add support for resource_limits when creating database users

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -91,6 +91,8 @@ mariadb_users: []
 #     host: 100.64.200.10
 #     password: password
 #     priv: "*.*:USAGE/db1.*:ALL"
+#     resource_limits:
+#       MAX_USER_CONNECTIONS: 20
 #     state: present|absent
 
 # Replication

--- a/molecule/default/vars/testvars.yml
+++ b/molecule/default/vars/testvars.yml
@@ -28,6 +28,13 @@ mariadb_users:
     password: user2passwd
     priv: "db2.*:ALL"
     state: present
+  - name: user3
+    host: "%"
+    password: user3passwd
+    priv: "db2.*:ALL"
+    resource_limits:
+      MAX_USER_CONNECTIONS: 20
+    state: present
 
 mariadb_replication_user:
   - name: ReplicationUser

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -9,5 +9,6 @@
     append_privs: "{{ item.append_privs | default('no') }}"
     encrypted: "{{ item.encrypted | default('no') }}"
     login_unix_socket: "{{ mariadb_unix_socket }}"
+    resource_limits: "{{ item.resource_limits | default({}) }}"
   loop: "{{ mariadb_users }}"
   no_log: true


### PR DESCRIPTION
Hello!

This PR adds support for the resource_limits parameter for community.mysql.mysql_user resource when creating users via the role.

Needed for limiting resources for users via automation.

Cheers Kalle