### PR TITLE
Allow override OS vars

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,15 +21,9 @@ mariadb_can_restart: true
 mariadb_overwrite_global_config_file: true
 
 # MariaDB configuration file
-mariadb_user: "default value depends on OS"
-mariadb_config_file: "default value depends on OS"
 # Basic settings
-mariadb_data_dir: "default value depends on OS"
 mariadb_port: 3306
 mariadb_bind_address: 127.0.0.1
-mariadb_pid_file: "default value depends on OS"
-mariadb_unix_socket: "default value depends on OS"
-mariadb_log_error_file: "default value depends on OS"
 mariadb_basic_settings_raw: |
   user                  = {{ mariadb_user }}
   pid-file              = {{ mariadb_pid_file }}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,13 +1,7 @@
 ---
-- name: Load OS-specific vars
-  ansible.builtin.include_vars: "{{ lookup('first_found', params) }}"
-  vars:
-    params:
-      files:
-        - "{{ ansible_distribution }}.yml"
-        - "{{ ansible_os_family }}.yml"
-      paths:
-        - "vars"
+# Variable configuration.
+- name: Include OS vars
+  ansible.builtin.include_tasks: variables.yml
 
 - name: Include task setup_debian.yml
   ansible.builtin.import_tasks: setup_debian.yml

--- a/tasks/variables.yml
+++ b/tasks/variables.yml
@@ -1,0 +1,56 @@
+---
+# Variable configuration.
+- name: Load OS-specific vars
+  ansible.builtin.include_vars: "{{ lookup('first_found', params) }}"
+  vars:
+    params:
+      files:
+        - "{{ ansible_distribution }}.yml"
+        - "{{ ansible_os_family }}.yml"
+      paths:
+        - "vars"
+
+- name: Define mariadb_user.
+  ansible.builtin.set_fact:
+    mariadb_user: "{{ __mariadb_user }}"
+  when: mariadb_user is not defined
+
+- name: Define mariadb_server_package.
+  ansible.builtin.set_fact:
+    mariadb_server_package: "{{ __mariadb_server_package }}"
+  when: mariadb_server_package is not defined
+
+- name: Define mariadb_config_file.
+  ansible.builtin.set_fact:
+    mariadb_config_file: "{{ __mariadb_config_file }}"
+  when: mariadb_config_file is not defined
+
+- name: Define mariadb_data_dir.
+  ansible.builtin.set_fact:
+    mariadb_data_dir: "{{ __mariadb_data_dir }}"
+  when: mariadb_data_dir is not defined
+
+- name: Define mariadb_pid_file.
+  ansible.builtin.set_fact:
+    mariadb_pid_file: "{{ __mariadb_pid_file }}"
+  when: mariadb_pid_file is not defined
+
+- name: Define mariadb_unix_socket.
+  ansible.builtin.set_fact:
+    mariadb_unix_socket: "{{ __mariadb_unix_socket }}"
+  when: mariadb_unix_socket is not defined
+
+- name: Define mariadb_log_dir.
+  ansible.builtin.set_fact:
+    mariadb_log_dir: "{{ __mariadb_log_dir }}"
+  when: mariadb_log_dir is not defined
+
+- name: Define mariadb_log_error_file.
+  ansible.builtin.set_fact:
+    mariadb_log_error_file: "{{ __mariadb_log_error_file }}"
+  when: mariadb_log_error_file is not defined
+
+- name: Define mariadb_cron_package_name.
+  ansible.builtin.set_fact:
+    mariadb_cron_package_name: "{{ __mariadb_cron_package_name }}"
+  when: mariadb_cron_package_name is not defined

--- a/vars/Alpine.yml
+++ b/vars/Alpine.yml
@@ -1,10 +1,10 @@
 ---
-mariadb_user: mysql
-mariadb_server_package: mariadb
-mariadb_config_file: "/etc/my.cnf.d/mariadb-server.cnf"
-mariadb_data_dir: "/var/lib/mysql"
-mariadb_pid_file: "/run/mysqld/mariadb.pid"
-mariadb_unix_socket: "/run/mysqld/mysqld.sock"
-mariadb_log_dir: "/var/log/mariadb"
-mariadb_log_error_file: "{{ mariadb_log_dir }}/error.log"
-mariadb_cron_package_name: "cronie"
+__mariadb_user: mysql
+__mariadb_server_package: mariadb
+__mariadb_config_file: "/etc/my.cnf.d/mariadb-server.cnf"
+__mariadb_data_dir: "/var/lib/mysql"
+__mariadb_pid_file: "/run/mysqld/mariadb.pid"
+__mariadb_unix_socket: "/run/mysqld/mysqld.sock"
+__mariadb_log_dir: "/var/log/mariadb"
+__mariadb_log_error_file: "{{ mariadb_log_dir }}/error.log"
+__mariadb_cron_package_name: "cronie"

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,10 +1,10 @@
 ---
-mariadb_user: mysql
-mariadb_server_package: mariadb-server
-mariadb_config_file: "/etc/mysql/mariadb.cnf"
-mariadb_data_dir: "/var/lib/mysql"
-mariadb_pid_file: "/run/mysqld/mysqld.pid"
-mariadb_unix_socket: "/run/mysqld/mysqld.sock"
-mariadb_log_dir: "/var/log/mysql"
-mariadb_log_error_file: "{{ mariadb_log_dir }}/error.log"
-mariadb_cron_package_name: "cron"
+__mariadb_user: mysql
+__mariadb_server_package: mariadb-server
+__mariadb_config_file: "/etc/mysql/mariadb.cnf"
+__mariadb_data_dir: "/var/lib/mysql"
+__mariadb_pid_file: "/run/mysqld/mysqld.pid"
+__mariadb_unix_socket: "/run/mysqld/mysqld.sock"
+__mariadb_log_dir: "/var/log/mysql"
+__mariadb_log_error_file: "{{ mariadb_log_dir }}/error.log"
+__mariadb_cron_package_name: "cron"

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,11 +1,11 @@
 ---
-mariadb_user: mysql
-mariadb_server_package: mariadb-server
-mariadb_server_package_mdbf: MariaDB-server
-mariadb_config_file: "/etc/my.cnf.d/mariadb-server.cnf"
-mariadb_data_dir: "/var/lib/mysql"
-mariadb_pid_file: "/run/mariadb/mysqld.pid"
-mariadb_unix_socket: "/var/lib/mysql/mysql.sock"
-mariadb_log_dir: "/var/log/mariadb"
-mariadb_log_error_file: "{{ mariadb_log_dir }}/error.log"
-mariadb_cron_package_name: "cronie"
+__mariadb_user: mysql
+__mariadb_server_package: mariadb-server
+__mariadb_server_package_mdbf: MariaDB-server
+__mariadb_config_file: "/etc/my.cnf.d/mariadb-server.cnf"
+__mariadb_data_dir: "/var/lib/mysql"
+__mariadb_pid_file: "/run/mariadb/mysqld.pid"
+__mariadb_unix_socket: "/var/lib/mysql/mysql.sock"
+__mariadb_log_dir: "/var/log/mariadb"
+__mariadb_log_error_file: "{{ mariadb_log_dir }}/error.log"
+__mariadb_cron_package_name: "cronie"


### PR DESCRIPTION
OS vars loaded at the begin, and thats override the variables from caller:

```- name: Install MariaDB
  ansible.builtin.import_role:
    name: fauust.mariadb
  vars:
    mariadb_config_file: "/etc/mysql/mariadb.conf.d/90-ansible.cnf"
```
This has no effect.

The patch change the logic same as [geerlingguy](https://github.com/geerlingguy/ansible-role-mysql/blob/master/tasks/variables.yml) solution: sets the variables from OS vars, if not defined.