### PR TITLE
cast to bool when checking conditions

### DIFF
--- a/tasks/setup_debian.yml
+++ b/tasks/setup_debian.yml
@@ -1,6 +1,6 @@
 ---
 - name: Install MariaDB official repository
-  when: mariadb_use_official_repo
+  when: mariadb_use_official_repo | bool
   block:
     - name: Install MariaDB repo necessary packages
       ansible.builtin.apt:
@@ -45,7 +45,7 @@
         owner: root
         group: root
         mode: "0644"
-      when: not mariadb_use_official_repo_format_deb822
+      when: not mariadb_use_official_repo_format_deb822 | bool
 
     - name: Setup MariaDB repository sources entry
       ansible.builtin.copy:
@@ -61,7 +61,7 @@
         owner: root
         group: root
         mode: "0644"
-      when: mariadb_use_official_repo_format_deb822
+      when: mariadb_use_official_repo_format_deb822 | bool
 
     - name: Prefer MariaDB repo over Debian repo
       ansible.builtin.copy:

--- a/tasks/setup_redhat.yml
+++ b/tasks/setup_redhat.yml
@@ -18,7 +18,7 @@
     owner: root
     group: root
     mode: "0644"
-  when: mariadb_use_official_repo
+  when: mariadb_use_official_repo | bool
 
 - name: Install packages (dnf)
   ansible.builtin.dnf:
@@ -36,7 +36,7 @@
       - MariaDB-backup
       - python3-PyMySQL
     state: present
-  when: mariadb_use_official_repo
+  when: mariadb_use_official_repo | bool
 
 # the following is needed since MDBF packages server installation doesn't
 # create the run dir directory which should probably be fixed upstream.
@@ -47,7 +47,7 @@
     owner: "{{ mariadb_user }}"
     group: "{{ mariadb_user }}"
     mode: 0755
-  when: mariadb_use_official_repo
+  when: mariadb_use_official_repo | bool
 
 - name: Check if mariadb command exists
   ansible.builtin.stat:


### PR DESCRIPTION
Hello, I'd like to introduce this small improvement because it blocks me from using this great role in my AWX instance. 

Problem:
I'm running this role via AWX and control role variables via Terraform provider.
Using such method it's not possible to pass true|false in plain mode, only as a string.
As a result l can't switch off flags because "false" is interpreted as true in current version.

Change description:
- add force boolean conversion in conditions  