### PR TITLE
Initialize database if using a custom data directory

### DIFF
--- a/.github/workflows/test_custom_datadir.yml
+++ b/.github/workflows/test_custom_datadir.yml
@@ -1,0 +1,45 @@
+---
+name: Cluster deployment with custom data directory
+
+on:
+  push:
+    paths:
+      - "files/**"
+      - "handlers/**"
+      - "molecule/default/**"
+      - "tasks/**"
+      - "templates/**"
+      - "vars/**"
+      - .github/workflows/composite-action/action.yml
+      - .github/workflows/test_custom_datadir.yml
+      - requirements.txt
+  schedule:
+    - cron: "0 5 * * 2"
+
+jobs:
+  molecule-distrib-pkg-custom-datadir:
+    name: Default deployment with custom data directory
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        distro:
+          - ubuntu-24.04
+          - debian-13
+          - fedora-42
+          - almalinux-9
+          - rockylinux-9
+          - alpine-3.23
+    steps:
+      - uses: actions/checkout@v6
+      - name: Setup environment
+        uses: ./.github/workflows/composite-action
+      - name: Run molecule
+        run: |
+          source .venv/bin/activate
+          molecule test -s cluster
+        env:
+          PY_COLORS: "1"
+          ANSIBLE_FORCE_COLOR: "1"
+          MOLECULE_DISTRO: ${{ matrix.distro }}
+          MOLECULE_PLAYBOOK: custom_datadir.yml

--- a/README.md
+++ b/README.md
@@ -130,9 +130,11 @@ deployments and you are encouraged to use your own values.
 
 ```yaml
 mariadb_user: "default value depends on OS"
+mariadb_group: "default value depends on OS"
 mariadb_server_package: "default value depends on OS"
 mariadb_config_file: "default value depends on OS"
 mariadb_data_dir: "default value depends on OS"
+mariadb_data_dir_permissions: "default value depends on OS"
 mariadb_port: 3306
 mariadb_bind_address: 127.0.0.1
 mariadb_unix_socket: "default value depends on OS"

--- a/molecule/cluster/custom_datadir.yml
+++ b/molecule/cluster/custom_datadir.yml
@@ -1,0 +1,10 @@
+---
+- name: Converge
+  hosts: all
+  gather_facts: true
+  vars:
+    mariadb_data_dir: /data
+  vars_files: vars/testvars.yml
+
+  roles:
+    - role: ansible-role-mariadb

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -31,6 +31,19 @@
           - conf.stat.pw_name == 'root'
           - conf.stat.gr_name == 'root'
 
+    - name: Register {{ mariadb_data_dir }}
+      ansible.builtin.stat:
+        path: "{{ mariadb_data_dir }}"
+      register: conf
+
+    - name: Check {{ mariadb_data_dir }}
+      ansible.builtin.assert:
+        that:
+          - conf.stat.exists is true
+          - conf.stat.pw_name == '{{ mariadb_user }}'
+          - conf.stat.gr_name == '{{ mariadb_group }}'
+          - conf.stat.mode == '{{ mariadb_data_dir_permissions }}'
+
     - name: Make sure that service is started
       ansible.builtin.service:
         name: mariadb

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -9,6 +9,19 @@
     force: "{{ mariadb_overwrite_global_config_file }}"
   notify: Restart mariadb
 
+- name: Ensure data directory is present and accessible
+  ansible.builtin.file:
+    path: "{{ mariadb_data_dir }}"
+    state: directory
+    owner: "{{ mariadb_user }}"
+    group: "{{ mariadb_group }}"
+    mode: "{{ mariadb_data_dir_permissions }}"
+
+- name: Handle DB initialisation for an empty custom directory
+  ansible.builtin.command:
+    cmd: "/usr/bin/mariadb-install-db {% if ansible_facts['os_family'] | lower == 'redhat' %}--rpm {% endif %}--cross-bootstrap --user={{ mariadb_user }} --disable-log-bin --skip-test-db"
+    creates: "{{ mariadb_data_dir }}/mysql"
+
 - name: Ensure MariaDB is started and enabled on boot
   ansible.builtin.service:
     name: mariadb

--- a/tasks/variables.yml
+++ b/tasks/variables.yml
@@ -15,6 +15,11 @@
     mariadb_user: "{{ __mariadb_user }}"
   when: mariadb_user is not defined
 
+- name: Define mariadb_group.
+  ansible.builtin.set_fact:
+    mariadb_group: "{{ __mariadb_user }}"
+  when: mariadb_group is not defined
+
 - name: Define mariadb_server_package.
   ansible.builtin.set_fact:
     mariadb_server_package: "{{ __mariadb_server_package }}"
@@ -36,6 +41,11 @@
   ansible.builtin.set_fact:
     mariadb_data_dir: "{{ __mariadb_data_dir }}"
   when: mariadb_data_dir is not defined
+
+- name: Define mariadb_data_dir permissions.
+  ansible.builtin.set_fact:
+    mariadb_data_dir_permissions: "{{ __mariadb_data_dir_permissions }}"
+  when: mariadb_data_dir_permissions is not defined
 
 - name: Define mariadb_pid_file.
   ansible.builtin.set_fact:

--- a/vars/Alpine.yml
+++ b/vars/Alpine.yml
@@ -1,5 +1,6 @@
 ---
 __mariadb_user: mysql
+__mariadb_group: mysql
 __mariadb_server_package: mariadb
 __mariadb_config_file: "/etc/my.cnf.d/mariadb-server.cnf"
 __mariadb_data_dir: "/var/lib/mysql"
@@ -8,3 +9,4 @@ __mariadb_unix_socket: "/run/mysqld/mysqld.sock"
 __mariadb_log_dir: "/var/log/mariadb"
 __mariadb_log_error_file: "{{ mariadb_log_dir }}/error.log"
 __mariadb_cron_package_name: "cronie"
+__mariadb_data_dir_permissions: "0750"

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,5 +1,6 @@
 ---
 __mariadb_user: mysql
+__mariadb_group: mysql
 __mariadb_server_package: mariadb-server
 __mariadb_config_file: "/etc/mysql/mariadb.cnf"
 __mariadb_data_dir: "/var/lib/mysql"
@@ -8,3 +9,4 @@ __mariadb_unix_socket: "/run/mysqld/mysqld.sock"
 __mariadb_log_dir: "/var/log/mysql"
 __mariadb_log_error_file: "{{ mariadb_log_dir }}/error.log"
 __mariadb_cron_package_name: "cron"
+__mariadb_data_dir_permissions: "0755"

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,5 +1,6 @@
 ---
 __mariadb_user: mysql
+__mariadb_group: mysql
 __mariadb_server_package: mariadb-server
 __mariadb_server_package_mdbf: MariaDB-server
 __mariadb_config_file: "/etc/my.cnf.d/mariadb-server.cnf"
@@ -9,3 +10,4 @@ __mariadb_unix_socket: "/var/lib/mysql/mysql.sock"
 __mariadb_log_dir: "/var/log/mariadb"
 __mariadb_log_error_file: "{{ mariadb_log_dir }}/error.log"
 __mariadb_cron_package_name: "cronie"
+__mariadb_data_dir_permissions: "0755"


### PR DESCRIPTION
OS and upstream packages initialize the database during postinstall, but only in the default database directory. For a custom data dir, the role is responsible to call the vendor supplied initialization script.

Changes:

- added OS dependent variable for custom data dir permissions. Can be overridden: it would break idempotecy, if different permissions are desired and set elsewhere.
- set data dir owner, group, and permissions.
- run (OS dependent) initialization if no database exists yet. Mariadb fails to start if the database is not properly initialized.
- updated README.
- added tests cases for OS and upstream packages (single instance only).

This PR fixes issue #61.