### PR TITLE
Needed on Debian Sid (systemd 259)

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -4,6 +4,8 @@ driver:
 platforms:
   - name: instance
     image: "ghcr.io/fauust/docker-ansible:${MOLECULE_DISTRO:-debian-11}"
+    capabilities:
+      - SYS_ADMIN
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     override_command: false


### PR DESCRIPTION
MariaDB Server refuse to start on Debian Sid (container) with systemd 259, error is:

```console
Feb 24 13:15:47 instance systemd[1]: Starting mariadb.service - MariaDB 11.8.6 database server... 
Feb 24 13:15:47 instance (sh)[1347]: mariadb.service: Failed to keep CAP_SYS_ADMIN: Operation not permitted
Feb 24 13:15:47 instance (sh)[1347]: mariadb.service: Failed at step USER spawning /bin/sh: Operation not permitted
```

See also: https://github.com/systemd/systemd/issues/34565